### PR TITLE
Drop unused typedef in boost::xpressive::detail::make_assert_word

### DIFF
--- a/include/boost/xpressive/detail/dynamic/parser.hpp
+++ b/include/boost/xpressive/detail/dynamic/parser.hpp
@@ -328,7 +328,6 @@ inline sequence<BidiIter> make_assert_end_line
 template<typename BidiIter, typename Cond, typename Traits>
 inline sequence<BidiIter> make_assert_word(Cond, Traits const &tr)
 {
-    typedef typename iterator_value<BidiIter>::type char_type;
     return detail::make_dynamic<BidiIter>
     (
         detail::assert_word_matcher<Cond, Traits>(tr)


### PR DESCRIPTION
This takes care of a warning that GCC post 4.8 emits.  The typedef indeed isn't used in the function and doesn't seem to serve a function (sometimes these typedefs are there in lieu of static asserts--this is not the case).
