### PR TITLE
Fix variable aliasing warnings

### DIFF
--- a/include/boost/xpressive/regex_compiler.hpp
+++ b/include/boost/xpressive/regex_compiler.hpp
@@ -442,20 +442,20 @@ private:
         if(lookahead)
         {
             seq += detail::make_independent_end_xpression<BidiIter>(seq.pure());
-            detail::lookahead_matcher<xpr_type> lookahead(seq.xpr(), negative, seq.pure());
-            seq = detail::make_dynamic<BidiIter>(lookahead);
+            detail::lookahead_matcher<xpr_type> lam(seq.xpr(), negative, seq.pure());
+            seq = detail::make_dynamic<BidiIter>(lam);
         }
         else if(lookbehind)
         {
             seq += detail::make_independent_end_xpression<BidiIter>(seq.pure());
-            detail::lookbehind_matcher<xpr_type> lookbehind(seq.xpr(), seq.width().value(), negative, seq.pure());
-            seq = detail::make_dynamic<BidiIter>(lookbehind);
+            detail::lookbehind_matcher<xpr_type> lbm(seq.xpr(), seq.width().value(), negative, seq.pure());
+            seq = detail::make_dynamic<BidiIter>(lbm);
         }
         else if(keeper) // independent sub-expression
         {
             seq += detail::make_independent_end_xpression<BidiIter>(seq.pure());
-            detail::keeper_matcher<xpr_type> keeper(seq.xpr(), seq.pure());
-            seq = detail::make_dynamic<BidiIter>(keeper);
+            detail::keeper_matcher<xpr_type> km(seq.xpr(), seq.pure());
+            seq = detail::make_dynamic<BidiIter>(km);
         }
 
         // restore the modifiers


### PR DESCRIPTION
MSVC 14 has new variable shadowing warnings, which are on by default and spam the Boost regression test output:
"warning C4456: declaration of '...' hides previous local declaration".
This renames a few variables to make MSVC happy.
