### PR TITLE
VxWorks support

### DIFF
--- a/include/boost/xpressive/traits/detail/c_ctype.hpp
+++ b/include/boost/xpressive/traits/detail/c_ctype.hpp
@@ -95,7 +95,7 @@ template<typename Char>
 struct char_class_impl;
 
 
-#if defined(__QNXNTO__)
+#if defined(__QNXNTO__) || defined(__VXWORKS__)
 
 ///////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
VxWorks uses same clib definitions as QNX, so with this change all xpressive tests passed