### PR TITLE
Avoid advancing null pointers, which is UB

### DIFF
--- a/include/boost/xpressive/detail/utility/sequence_stack.hpp
+++ b/include/boost/xpressive/detail/utility/sequence_stack.hpp
@@ -15,6 +15,7 @@
 # pragma warning(disable : 4127) // conditional expression constant
 #endif
 
+#include <cstddef>
 #include <algorithm>
 #include <functional>
 
@@ -210,21 +211,19 @@ public:
 
     T *push_sequence(std::size_t count, T const &t)
     {
+        // Check to see if we have overflowed this buffer
+        std::size_t size_left = static_cast< std::size_t >(this->end_ - this->curr_);
+        if (size_left < count)
+        {
+            // allocate a new block and return a ptr to the new memory
+            return this->grow_(count, t);
+        }
+
         // This is the ptr to return
         T *ptr = this->curr_;
 
         // Advance the high-water mark
         this->curr_ += count;
-
-        // Check to see if we have overflowed this buffer
-        if(std::less<void*>()(this->end_, this->curr_))
-        {
-            // oops, back this out.
-            this->curr_ = ptr;
-
-            // allocate a new block and return a ptr to the new memory
-            return this->grow_(count, t);
-        }
 
         return ptr;
     }


### PR DESCRIPTION
Advancing a null pointer by a distance other than 0 is UB in C++20 (7.6.6 Additive operators [expr.add]/4).

This issue is reported by clang 10 UBSan here:

https://travis-ci.org/github/boostorg/log/jobs/683550541#L1204

Also, add a missing include for `std::size_t`.
