### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/xpressive

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/xpressive
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,36 +5,39 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/conversion//boost_conversion
+    /boost/core//boost_core
+    /boost/exception//boost_exception
+    /boost/fusion//boost_fusion
+    /boost/integer//boost_integer
+    /boost/iterator//boost_iterator
+    /boost/lexical_cast//boost_lexical_cast
+    /boost/mpl//boost_mpl
+    /boost/numeric_conversion//boost_numeric_conversion
+    /boost/optional//boost_optional
+    /boost/preprocessor//boost_preprocessor
+    /boost/proto//boost_proto
+    /boost/range//boost_range
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/typeof//boost_typeof
+    /boost/utility//boost_utility ;
+
 project /boost/xpressive
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/conversion//boost_conversion
-        <library>/boost/core//boost_core
-        <library>/boost/exception//boost_exception
-        <library>/boost/fusion//boost_fusion
-        <library>/boost/integer//boost_integer
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/lexical_cast//boost_lexical_cast
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/numeric_conversion//boost_numeric_conversion
-        <library>/boost/optional//boost_optional
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/proto//boost_proto
-        <library>/boost/range//boost_range
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/typeof//boost_typeof
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_xpressive ]
+    [ alias boost_xpressive : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_xpressive example perf test tools ]
     ;
 
 call-if : boost-library xpressive
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,27 +7,27 @@ import project ;
 
 project /boost/xpressive
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/conversion//boost_conversion
-        <source>/boost/core//boost_core
-        <source>/boost/exception//boost_exception
-        <source>/boost/fusion//boost_fusion
-        <source>/boost/integer//boost_integer
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/lexical_cast//boost_lexical_cast
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/numeric_conversion//boost_numeric_conversion
-        <source>/boost/optional//boost_optional
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/proto//boost_proto
-        <source>/boost/range//boost_range
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/typeof//boost_typeof
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/conversion//boost_conversion
+        <library>/boost/core//boost_core
+        <library>/boost/exception//boost_exception
+        <library>/boost/fusion//boost_fusion
+        <library>/boost/integer//boost_integer
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/lexical_cast//boost_lexical_cast
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/numeric_conversion//boost_numeric_conversion
+        <library>/boost/optional//boost_optional
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/proto//boost_proto
+        <library>/boost/range//boost_range
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/typeof//boost_typeof
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,40 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/xpressive
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/conversion//boost_conversion
+        <source>/boost/core//boost_core
+        <source>/boost/exception//boost_exception
+        <source>/boost/fusion//boost_fusion
+        <source>/boost/integer//boost_integer
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/lexical_cast//boost_lexical_cast
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/numeric_conversion//boost_numeric_conversion
+        <source>/boost/optional//boost_optional
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/proto//boost_proto
+        <source>/boost/range//boost_range
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/typeof//boost_typeof
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_xpressive ]
+    [ alias all : boost_xpressive example perf test tools ]
+    ;
+
+call-if : boost-library xpressive
+    ;

--- a/build.jam
+++ b/build.jam
@@ -29,12 +29,11 @@ constant boost_dependencies :
     /boost/utility//boost_utility ;
 
 project /boost/xpressive
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_xpressive : : : : <library>$(boost_dependencies) ]
+    [ alias boost_xpressive : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_xpressive example perf test tools ]
     ;
 

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -7,8 +7,8 @@ import quickbook ;
 
 doxygen autodoc
     :
-        [ glob ../../../boost/xpressive/*.hpp ]
-        [ glob ../../../boost/xpressive/traits/*.hpp ]
+        [ glob ../include/boost/xpressive/*.hpp ]
+        [ glob ../include/boost/xpressive/traits/*.hpp ]
     :
         <doxygen:param>EXTRACT_ALL=YES
         <doxygen:param>"PREDEFINED=\"BOOST_XPRESSIVE_DOXYGEN_INVOKED\" \\

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -4,6 +4,7 @@
 
 project
     : requirements
+        <library>/boost/xpressive//boost_xpressive
         <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc,<stdlib>stlport:<define>_STLP_EXPOSE_GLOBALS_IMPLEMENTATION

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -7,18 +7,15 @@ project
         <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc,<stdlib>stlport:<define>_STLP_EXPOSE_GLOBALS_IMPLEMENTATION
+        <source>/boost/assign//boost_assign
     ;
 
 exe examples 
     :
         main.cpp
-    :
-        <include>$(BOOST_ROOT)
     ;
 
 exe numbers
     :
         numbers.cpp
-    :
-        <include>$(BOOST_ROOT)
     ;

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -7,10 +7,10 @@ project
         <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc,<stdlib>stlport:<define>_STLP_EXPOSE_GLOBALS_IMPLEMENTATION
-        <source>/boost/assign//boost_assign
+        <library>/boost/assign//boost_assign
     ;
 
-exe examples 
+exe examples
     :
         main.cpp
     ;

--- a/perf/Jamfile.v2
+++ b/perf/Jamfile.v2
@@ -8,25 +8,6 @@
 #    : requirements <library>../../../../boost/libs/regex/build//boost_regex
 #    ;
 
-BOOST_REGEX_SOURCES =
-   c_regex_traits
-   cpp_regex_traits
-   cregex
-   fileiter
-   icu
-   instances
-   posix_api
-   regex
-   regex_debug
-   regex_raw_buffer
-   regex_traits_defaults
-   static_mutex
-   w32_regex_traits
-   wc_regex_traits
-   wide_posix_api
-   winstances
-   usinstances ;
-
 exe xprperf 
     : 
         command_line.cpp
@@ -34,11 +15,10 @@ exe xprperf
         time_boost.cpp
         time_dynamic_xpressive.cpp
         time_static_xpressive.cpp
-        $(BOOST_ROOT)/libs/regex/src/$(BOOST_REGEX_SOURCES).cpp
+        /boost/regex//boost_regex
+        /boost/timer//boost_timer
+        /boost/test//boost_unit_test_framework
     :
-        <include>$(BOOST_ROOT)
-        <define>BOOST_REGEX_NO_LIB=1
-        <define>BOOST_REGEX_RECURSIVE
-        <define>BOOST_REGEX_USE_CPP_LOCALE
         <define>BOOST_XPRESSIVE_USE_CPP_TRAITS
+        <define>BOOST_TIMER_ENABLE_DEPRECATED
     ;

--- a/perf/Jamfile.v2
+++ b/perf/Jamfile.v2
@@ -4,12 +4,8 @@
 # License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-#project
-#    : requirements <library>../../../../boost/libs/regex/build//boost_regex
-#    ;
-
-exe xprperf 
-    : 
+exe xprperf
+    :
         command_line.cpp
         main.cpp
         time_boost.cpp

--- a/perf/Jamfile.v2
+++ b/perf/Jamfile.v2
@@ -4,6 +4,8 @@
 # License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+project : requirements <library>/boost/xpressive//boost_xpressive ;
+
 exe xprperf
     :
         command_line.cpp

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,6 +7,7 @@ import testing ;
 
 project
     : requirements
+        <library>/boost/xpressive//boost_xpressive
         <toolset>intel:<debug-symbols>off
         # Turn off debug symbols on MSVC to bring down the size of object files
         <toolset>msvc:<debug-symbols>off

--- a/tools/Jamfile.v2
+++ b/tools/Jamfile.v2
@@ -16,6 +16,4 @@ project
 exe perl2xpr
     :
         perl2xpr.cpp
-    :
-        <include>$(BOOST_ROOT)
     ;

--- a/tools/Jamfile.v2
+++ b/tools/Jamfile.v2
@@ -4,6 +4,7 @@
 
 project
     : requirements
+        <library>/boost/xpressive//boost_xpressive
         <toolset>intel:<debug-symbols>off
         <toolset>msvc-7.1:<debug-symbols>off
         <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.