### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(boost_xpressive
     Boost::proto
     Boost::range
     Boost::smart_ptr
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
     Boost::typeof

--- a/build.jam
+++ b/build.jam
@@ -22,7 +22,6 @@ constant boost_dependencies :
     /boost/proto//boost_proto
     /boost/range//boost_range
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits
     /boost/typeof//boost_typeof


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.